### PR TITLE
Fix for font anti aliasing in sprites

### DIFF
--- a/Extensions/Sprite.cpp
+++ b/Extensions/Sprite.cpp
@@ -1525,7 +1525,7 @@ void TFT_eSprite::drawGlyph(uint16_t code)
           if (pixel != 0xFF)
           {
             if (dl) { drawFastHLine( xs, y + this->cursor_y + this->gFont.maxAscent - this->gdY[gNum], dl, fg); dl = 0; }
-            if (pixel>127) drawPixel(x + this->cursor_x + this->gdX[gNum], y + this->cursor_y + this->gFont.maxAscent - this->gdY[gNum], alphaBlend(pixel, fg, bg));
+            drawPixel(x + this->cursor_x + this->gdX[gNum], y + this->cursor_y + this->gFont.maxAscent - this->gdY[gNum], alphaBlend(pixel, fg, bg));
           }
           else
           {


### PR DESCRIPTION
Currently, smooth fonts are antialiased differently depending on whether they are drawn directly on a TFT or drawn on a sprite and then pushed to the TFT.  In my opinion, the anti aliasing should be consistent, regardless of where the text is being drawn. 
 Digging into the libraries, I noticed that drawGlyph() in Sprite.cpp overrides drawGlyph() in Smooth_font.cpp.  For some reason, in Sprite.cpp, drawPixel() was only being called if the alpha value of the pixel was greater than 127.  Removing the "if" statement and calling drawPixel() regardless of the alpha value of that pixel, resolves the inconsistency and produces great looking text!